### PR TITLE
Inject io.Writer to the SourceRunner instead of using an internal io.WriteCloser

### DIFF
--- a/example_source_test.go
+++ b/example_source_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/bitstrapped/airbyte"
@@ -216,7 +217,7 @@ func (h HTTPSource) Read(sourceCfgPath string, prevStatePath string, configuredC
 
 func Example() {
 	hsrc := NewHTTPSource("https://api.bitstrapped.com")
-	runner := airbyte.NewSourceRunner(hsrc)
+	runner := airbyte.NewSourceRunner(hsrc, os.Stdout)
 	err := runner.Start()
 	if err != nil {
 		log.Fatal(err)

--- a/examples/httpsource/main.go
+++ b/examples/httpsource/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/bitstrapped/airbyte"
 	"github.com/bitstrapped/airbyte/examples/httpsource/apisource"
@@ -9,7 +10,7 @@ import (
 
 func main() {
 	hsrc := apisource.NewAPISource("https://api.bitstrapped.com")
-	runner := airbyte.NewSourceRunner(hsrc)
+	runner := airbyte.NewSourceRunner(hsrc, os.Stdout)
 	err := runner.Start()
 	if err != nil {
 		log.Fatal(err)

--- a/protocol.go
+++ b/protocol.go
@@ -254,7 +254,7 @@ type StateWriter func(v interface{}) error
 // RecordWriter is exported for documentation purposes - only use this through MessageTracker
 type RecordWriter func(v interface{}, streamName string, namespace string) error
 
-func newLogWriter(w io.WriteCloser) LogWriter {
+func newLogWriter(w io.Writer) LogWriter {
 	return func(lvl LogLevel, s string) error {
 		return write(w, &message{
 			Type: msgTypeLog,
@@ -266,7 +266,7 @@ func newLogWriter(w io.WriteCloser) LogWriter {
 	}
 
 }
-func newStateWriter(w io.WriteCloser) StateWriter {
+func newStateWriter(w io.Writer) StateWriter {
 	return func(s interface{}) error {
 		return write(w, &message{
 			Type: msgTypeState,
@@ -277,7 +277,7 @@ func newStateWriter(w io.WriteCloser) StateWriter {
 	}
 }
 
-func newRecordWriter(w io.WriteCloser) RecordWriter {
+func newRecordWriter(w io.Writer) RecordWriter {
 	return func(s interface{}, stream string, namespace string) error {
 		return write(w, &message{
 			Type: msgTypeRecord,

--- a/safewriter.go
+++ b/safewriter.go
@@ -1,7 +1,6 @@
 package airbyte
 
 import (
-	"bufio"
 	"io"
 	"sync"
 )
@@ -13,7 +12,7 @@ type safeWriter struct {
 
 func newSafeWriter(w io.Writer) io.Writer {
 	return &safeWriter{
-		w: bufio.NewWriter(w),
+		w: w,
 	}
 }
 

--- a/safewriter.go
+++ b/safewriter.go
@@ -1,18 +1,19 @@
 package airbyte
 
 import (
+	"bufio"
 	"io"
 	"sync"
 )
 
 type safeWriter struct {
-	w  io.WriteCloser
+	w  io.Writer
 	mu sync.Mutex
 }
 
-func newSafeWriteCloser(w io.WriteCloser) io.WriteCloser {
+func newSafeWriter(w io.Writer) io.Writer {
 	return &safeWriter{
-		w: w,
+		w: bufio.NewWriter(w),
 	}
 }
 
@@ -20,10 +21,4 @@ func (sw *safeWriter) Write(p []byte) (int, error) {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()
 	return sw.w.Write(p)
-}
-
-func (sw *safeWriter) Close() error {
-	sw.mu.Lock()
-	defer sw.mu.Unlock()
-	return sw.w.Close()
 }

--- a/sourceRunner.go
+++ b/sourceRunner.go
@@ -8,14 +8,14 @@ import (
 
 // SourceRunner acts as an "orchestrator" of sorts to run your source for you
 type SourceRunner struct {
-	w          io.WriteCloser
+	w          io.Writer
 	src        Source
 	msgTracker MessageTracker
 }
 
 // NewSourceRunner takes your defined Source and plugs it in with the rest of airbyte
-func NewSourceRunner(src Source) SourceRunner {
-	w := newSafeWriteCloser(os.Stdout)
+func NewSourceRunner(src Source, w io.Writer) SourceRunner {
+	w = newSafeWriter(w)
 	msgTracker := MessageTracker{
 		Record: newRecordWriter(w),
 		State:  newStateWriter(w),


### PR DESCRIPTION
Leave the close and flush details to the user. This way it easily use specific writers and be used in different contextes without changing any internals. 